### PR TITLE
Provide a basic GH Action for CI

### DIFF
--- a/.github/workflows/chronicles.yml
+++ b/.github/workflows/chronicles.yml
@@ -1,6 +1,10 @@
 name: Chronicles CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/chronicles.yml
+++ b/.github/workflows/chronicles.yml
@@ -1,0 +1,17 @@
+name: Chronicles CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Run tests
+      run: sbt test


### PR DESCRIPTION
This will run `sbt test` for the root project, which is configured in `build.sbt` to aggregate all sub-projects.

This will trigger on `push` events to `master` and `pull_request` events to the repository itself (including from forks.)

Resolves #26.