### PR TITLE
Change Version Tracker API to return Streams instead of Lists

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,10 @@ lazy val chronicles = (project in file("."))
 lazy val `chronicles-core` = project
   .in(file("core"))
   .settings(commonSettings)
-  .settings(libraryDependencies ++= catsDependencies)
+  .settings(
+    libraryDependencies ++= catsDependencies ++ Seq(
+      "co.fs2" %% "fs2-core" % fs2Version
+    ))
 
 lazy val `chronicles-db` = project
   .in(file("db"))

--- a/cli/src/main/scala/dev/chronicles/cli/Console.scala
+++ b/cli/src/main/scala/dev/chronicles/cli/Console.scala
@@ -1,6 +1,8 @@
 package dev.chronicles.cli
 
+import cats.Functor
 import cats.effect._
+import fs2.Stream
 
 import scala.io.StdIn
 
@@ -10,11 +12,19 @@ import scala.io.StdIn
 trait Console[F[_]] {
   def println(msg: String): F[Unit]
   def errorln(msg: String): F[Unit]
+
+  def printlns(msgs: Stream[F, String])(implicit F: Functor[F]): Stream[F, String] =
+    msgs.evalTap(println)
+
+  def errorlns(msgs: Stream[F, String])(implicit F: Functor[F]): Stream[F, String] =
+    msgs.evalTap(println)
+
   def readLine(prompt: String): F[Option[String]]
 }
 
 object Console {
 
+  /** Create console implementation that uses stdin/stdout. */
   def apply[F[_]: Sync: ContextShift]: F[Console[F]] =
     Sync[F].delay {
       new Console[F] {
@@ -27,6 +37,7 @@ object Console {
         def readLine(prompt: String): F[Option[String]] =
           Sync[F]
             .delay(Option(StdIn.readLine(prompt)): Option[String])
+
       }
     }
 

--- a/cli/src/main/scala/dev/chronicles/cli/Console.scala
+++ b/cli/src/main/scala/dev/chronicles/cli/Console.scala
@@ -1,6 +1,5 @@
 package dev.chronicles.cli
 
-import cats.Functor
 import cats.effect._
 import fs2.Stream
 
@@ -12,14 +11,10 @@ import scala.io.StdIn
 trait Console[F[_]] {
   def println(msg: String): F[Unit]
   def errorln(msg: String): F[Unit]
-
-  def printlns(msgs: Stream[F, String])(implicit F: Functor[F]): Stream[F, String] =
-    msgs.evalTap(println)
-
-  def errorlns(msgs: Stream[F, String])(implicit F: Functor[F]): Stream[F, String] =
-    msgs.evalTap(println)
-
   def readLine(prompt: String): F[Option[String]]
+
+  final def printlns(msgs: Stream[F, String]): Stream[F, Unit] =
+    msgs.evalMap(println)
 }
 
 object Console {

--- a/cli/src/test/scala/dev/chronicles/cli/ChroniclesCliSpec.scala
+++ b/cli/src/test/scala/dev/chronicles/cli/ChroniclesCliSpec.scala
@@ -103,7 +103,6 @@ class ChroniclesCliSpec extends FlatSpec with Matchers {
     val consoleOutput = scenario.unsafeRunSync()
 
     consoleOutput should contain theSameElementsInOrderAs List(
-      StdOut(""),
       StdOut("Initialised table db.test_table"),
       StdOut("db.test_table")
     )

--- a/core/src/main/scala/dev/chronicles/core/InMemoryVersionTracker.scala
+++ b/core/src/main/scala/dev/chronicles/core/InMemoryVersionTracker.scala
@@ -18,10 +18,7 @@ class InMemoryVersionTracker[F[_]] private (allUpdates: Ref[F, TableUpdates])(im
     extends VersionTracker[F] {
 
   override def tables(): Stream[F, TableName] =
-    for {
-      allTableUpdates <- Stream.eval(allUpdates.get)
-      updates <- Stream.emits(allTableUpdates.keys.toList)
-    } yield updates
+    Stream.eval(allUpdates.get).map(_.keys.toList) >>= Stream.emits
 
   override def commit(table: TableName, update: VersionTracker.TableUpdate): F[Unit] = {
     val applyUpdate: TableUpdates => Either[Exception, TableUpdates] = { currentTableUpdates =>

--- a/core/src/main/scala/dev/chronicles/core/VersionTracker.scala
+++ b/core/src/main/scala/dev/chronicles/core/VersionTracker.scala
@@ -44,9 +44,9 @@ trait VersionTracker[F[_]] {
       isSnapshot <- Stream.eval(isSnapshotTable(table))
 
       tableVersion <- if (isSnapshot)
-        latestSnapshotTableVersion[F](operations).covaryOutput[TableVersion]
+        latestSnapshotTableVersion[F](operations)
       else
-        applyPartitionUpdates(PartitionedTableVersion(Map.empty))(operations).covaryOutput[TableVersion]
+        applyPartitionUpdates(PartitionedTableVersion(Map.empty))(operations)
     } yield tableVersion
 
     aggregateTableVersion.head.compile.lastOrError

--- a/core/src/main/scala/dev/chronicles/core/VersionTracker.scala
+++ b/core/src/main/scala/dev/chronicles/core/VersionTracker.scala
@@ -4,9 +4,9 @@ import java.time.Instant
 import java.util.UUID
 
 import cats.effect.Sync
-import cats.implicits._
 import dev.chronicles.core.VersionTracker.TableOperation._
 import dev.chronicles.core.VersionTracker._
+import fs2.Stream
 
 /**
   * This defines the interface for querying and updating table version information tracked by the system.
@@ -16,7 +16,7 @@ trait VersionTracker[F[_]] {
   /**
     * List all known tables.
     */
-  def tables(): F[List[TableName]]
+  def tables(): Stream[F, TableName]
 
   /**
     * Start tracking version information for given table.
@@ -32,23 +32,32 @@ trait VersionTracker[F[_]] {
   /**
     * Get details about partition versions in a table.
     */
-  def currentVersion(table: TableName)(implicit F: Sync[F]): F[TableVersion] =
+  def currentVersion(table: TableName)(implicit F: Sync[F]): F[TableVersion] = {
     // Derive current version of a table by folding over the history of changes
     // until either the latest or version marked as 'current' is reached.
-    for {
-      ts <- tableState(table)
-      matchingUpdates = ts.updates.span(_.metadata.id != ts.currentVersion)
-      updatesForCurrentVersion = matchingUpdates._1 ++ matchingUpdates._2.take(1)
-      operations = updatesForCurrentVersion.flatMap(_.operations)
-    } yield
-      if (isSnapshotTable(operations))
-        latestSnapshotTableVersion(operations)
+    val aggregateTableVersion = for {
+      ts <- Stream.eval(tableState(table))
+      updatesForCurrentVersion = ts.updates.takeThrough(_.metadata.id != ts.currentVersion)
+
+      //operations = updatesForCurrentVersion.flatMap(update => Stream.emits(update.operations))
+      operations <- updatesForCurrentVersion.map(update => Stream.emits(update.operations))
+
+      snapshotTable <- Stream.eval(isSnapshotTable(table))
+
+      tableVersion <- if (snapshotTable)
+        latestSnapshotTableVersion[F](operations).covaryOutput[TableVersion]
       else
-        applyPartitionUpdates(PartitionedTableVersion(Map.empty))(operations)
+        applyPartitionUpdates(PartitionedTableVersion(Map.empty))(operations).covaryOutput[TableVersion]
+    } yield tableVersion
+
+    aggregateTableVersion.head.compile.lastOrError
+  }
 
   /** Return the history of table updates, most recent first. */
-  def updates(table: TableName)(implicit F: Sync[F]): F[List[TableUpdateMetadata]] =
-    tableState(table).map(_.updates.map(_.metadata).reverse)
+  def updates(table: TableName)(implicit F: Sync[F]): Stream[F, TableUpdateMetadata] =
+    Stream
+      .eval(tableState(table))
+      .flatMap(_.updates.map(_.metadata))
 
   /**
     * Update partition versions to the given versions.
@@ -60,6 +69,11 @@ trait VersionTracker[F[_]] {
     */
   def setCurrentVersion(table: TableName, id: VersionTracker.CommitId): F[Unit]
 
+  /**
+    * Get the flag that indicates whether a table is a snapshot table or not.
+    */
+  def isSnapshotTable(table: TableName): F[Boolean]
+
   //
   // Internal operations to be provided by implementations
   //
@@ -67,7 +81,7 @@ trait VersionTracker[F[_]] {
   /**
     * Produce description of the current state of table.
     */
-  protected def tableState(table: TableName): F[TableState]
+  protected def tableState(table: TableName): F[TableState[F]]
 
 }
 
@@ -128,13 +142,13 @@ object VersionTracker {
     * @param updates The list of updates that has been performed on the table.
     *                These must be returned in the order they were executed.
     */
-  final case class TableState(currentVersion: CommitId, updates: List[TableUpdate])
+  final case class TableState[F[_]](currentVersion: CommitId, updates: Stream[F, TableUpdate])
 
   /**
     * Produce current partitioned table version based on history of partition updates.
     */
-  def applyPartitionUpdates(initial: PartitionedTableVersion)(
-      operations: List[TableOperation]): PartitionedTableVersion = {
+  private[core] def applyPartitionUpdates[F[_]](initial: PartitionedTableVersion)(
+      operations: Stream[F, TableOperation]): Stream[F, PartitionedTableVersion] = {
 
     def applyOp(agg: Map[Partition, Version], op: TableOperation): Map[Partition, Version] = op match {
       case AddPartitionVersion(partition: Partition, version: Version) =>
@@ -144,25 +158,23 @@ object VersionTracker {
       case _: InitTable | _: AddTableVersion => agg
     }
 
-    val latestVersions = operations.foldLeft(initial.partitionVersions)(applyOp)
+    val latestVersions = operations.fold(initial.partitionVersions)(applyOp)
 
-    PartitionedTableVersion(latestVersions)
+    latestVersions
+      .lastOr(initial.partitionVersions)
+      .map(partitionVersions => PartitionedTableVersion(partitionVersions))
   }
 
   /**
     * Produce current snapshot table version based on history of table version updates.
     */
-  def latestSnapshotTableVersion(operations: List[TableOperation]): SnapshotTableVersion = {
-    val versions = operations.collect {
-      case AddTableVersion(version) => version
-    }
-    SnapshotTableVersion(versions.lastOption.getOrElse(Version.Unversioned))
-  }
-
-  def isSnapshotTable(operations: List[TableOperation]): Boolean = operations match {
-    case InitTable(_, isSnapshot) :: _ => isSnapshot
-    case _                             => throw new IllegalArgumentException("First operation should be initialising the table")
-  }
+  private def latestSnapshotTableVersion[F[_]](operations: Stream[F, TableOperation]): Stream[F, SnapshotTableVersion] =
+    operations
+      .collect {
+        case AddTableVersion(version) => version
+      }
+      .lastOr(Version.Unversioned)
+      .map(SnapshotTableVersion)
 
   // Errors
 

--- a/core/src/main/scala/dev/chronicles/core/VersionedMetastore.scala
+++ b/core/src/main/scala/dev/chronicles/core/VersionedMetastore.scala
@@ -6,6 +6,7 @@ import cats.effect.Sync
 import cats.implicits._
 import dev.chronicles.core.Metastore.TableChanges
 import dev.chronicles.core.VersionTracker._
+import fs2.Stream
 
 /**
   * High level API for table version tracking, that aggregates the functionality from VersionTracker and Metastore
@@ -16,7 +17,7 @@ final class VersionedMetastore[F[_]: Sync](versionTracker: VersionTracker[F], me
   /**
     * List all known tables.
     */
-  def tables(): F[List[TableName]] =
+  def tables(): Stream[F, TableName] =
     versionTracker.tables()
 
   /**
@@ -40,7 +41,7 @@ final class VersionedMetastore[F[_]: Sync](versionTracker: VersionTracker[F], me
   /**
     * Get the history of updates for a given table, most recent first.
     */
-  def updates(table: TableName): F[List[TableUpdateMetadata]] =
+  def updates(table: TableName): Stream[F, TableUpdateMetadata] =
     versionTracker.updates(table)
 
   /**

--- a/core/src/main/scala/dev/chronicles/core/model.scala
+++ b/core/src/main/scala/dev/chronicles/core/model.scala
@@ -110,7 +110,7 @@ final case class TableDefinition(name: TableName, location: URI, partitionSchema
 /**
   * The complete set of version information for all partitions in a table.
   */
-sealed trait TableVersion
+sealed trait TableVersion extends Product with Serializable
 final case class PartitionedTableVersion(partitionVersions: Map[Partition, Version]) extends TableVersion
 final case class SnapshotTableVersion(version: Version) extends TableVersion
 

--- a/core/src/test/scala/dev/chronicles/core/VersionTrackerSpec.scala
+++ b/core/src/test/scala/dev/chronicles/core/VersionTrackerSpec.scala
@@ -37,13 +37,13 @@ trait VersionTrackerSpec {
       val scenario = for {
         versionTracker <- initialVersionTracker
 
-        tablesBeforeInit <- versionTracker.tables()
+        tablesBeforeInit <- versionTracker.tables().compile.toList
 
         _ <- versionTracker.initTable(table, isSnapshot = false, userId, UpdateMessage("init table 1"), Instant.now())
-        tables1 <- versionTracker.tables()
+        tables1 <- versionTracker.tables().compile.toList
 
         _ <- versionTracker.initTable(table2, isSnapshot = false, userId, UpdateMessage("init table 2"), Instant.now())
-        tables2 <- versionTracker.tables()
+        tables2 <- versionTracker.tables().compile.toList
 
       } yield (tablesBeforeInit, tables1, tables2)
 
@@ -243,7 +243,7 @@ trait VersionTrackerSpec {
         versionTracker <- initialVersionTracker
         _ <- versionTracker.initTable(table, isSnapshot = false, userId, UpdateMessage("init"), timestamp(0))
 
-        historyAfterInit <- versionTracker.updates(table)
+        historyAfterInit <- versionTracker.updates(table).compile.toList
 
         _ <- versionTracker.commit(table, tableUpdate1)
         _ <- versionTracker.commit(table, tableUpdate2)
@@ -252,7 +252,7 @@ trait VersionTrackerSpec {
         versionAfterWrites <- versionTracker.currentVersion(table)
 
         // Get the update history after updates
-        fullHistory <- versionTracker.updates(table)
+        fullHistory <- versionTracker.updates(table).compile.toList
 
         // Setting the current version to the latest should have no effect
         _ <- versionTracker.setCurrentVersion(table, fullHistory.head.id)
@@ -331,7 +331,7 @@ trait VersionTrackerSpec {
         versionTracker <- initialVersionTracker
         _ <- versionTracker.initTable(table, isSnapshot = true, userId, UpdateMessage("init"), Instant.now())
 
-        historyAfterInit <- versionTracker.updates(table)
+        historyAfterInit <- versionTracker.updates(table).compile.toList
 
         _ <- versionTracker.commit(table, tableUpdate1)
         _ <- versionTracker.commit(table, tableUpdate2)
@@ -340,7 +340,7 @@ trait VersionTrackerSpec {
         versionAfterWrites <- versionTracker.currentVersion(table)
 
         // Get the update history after updates
-        fullHistory <- versionTracker.updates(table)
+        fullHistory <- versionTracker.updates(table).compile.toList
 
         // Setting the current version to the latest should have no effect
         _ <- versionTracker.setCurrentVersion(table, fullHistory.head.id)
@@ -418,7 +418,7 @@ trait VersionTrackerSpec {
         // Commit all the updates
         _ <- tableUpdates.map(update => versionTracker.commit(table, update)).sequence
 
-        updateHistory <- versionTracker.updates(table)
+        updateHistory <- versionTracker.updates(table).compile.toList
 
       } yield (tableUpdates, updateHistory)
 
@@ -457,7 +457,7 @@ trait VersionTrackerSpec {
     it should "return an error if trying to get the version history for an unknown table" in {
       val scenario = for {
         versionTracker <- initialVersionTracker
-        _ <- versionTracker.updates(table)
+        _ <- versionTracker.updates(table).compile.toList
       } yield ()
 
       val ex = the[Exception] thrownBy scenario.unsafeRunSync()

--- a/core/src/test/scala/dev/chronicles/core/VersionTrackerSpec.scala
+++ b/core/src/test/scala/dev/chronicles/core/VersionTrackerSpec.scala
@@ -103,6 +103,8 @@ trait VersionTrackerSpec {
                       initialPartitionVersions.map(AddPartitionVersion.tupled).toList)
         )
 
+        updates1 <- versionTracker.updates(table).compile.toList
+
         tableVersion1 <- versionTracker.currentVersion(table)
 
         // Do an update with one updated partition and one new one
@@ -113,12 +115,14 @@ trait VersionTrackerSpec {
                                                partitionUpdate1.map(AddPartitionVersion.tupled).toList))
         tableVersion2 <- versionTracker.currentVersion(table)
 
-      } yield (initialTableVersion, tableVersion1, tableVersion2)
+      } yield (initialTableVersion, updates1, tableVersion1, tableVersion2)
 
-      val (initialTableVersion, tableVersion1, tableVersion2) =
+      val (initialTableVersion, updates1, tableVersion1, tableVersion2) =
         scenario.unsafeRunSync()
 
       initialTableVersion shouldBe PartitionedTableVersion(Map.empty)
+
+      updates1.map(_.message.content) should contain theSameElementsAs List("Add initial partitions", "init")
       tableVersion1 shouldBe PartitionedTableVersion(initialPartitionVersions)
 
       tableVersion2 shouldEqual PartitionedTableVersion(

--- a/db/src/it/scala/dev/chronicles/db/DbVersionTrackerIntegrationTest.scala
+++ b/db/src/it/scala/dev/chronicles/db/DbVersionTrackerIntegrationTest.scala
@@ -24,7 +24,8 @@ class DbVersionTrackerIntegrationTest extends FlatSpec with Matchers with doobie
 
   "getAllTables" should "be valid" in { check(DbVersionTracker.getAllTables) }
   "getTableMetadata" should "be valid" in { check(DbVersionTracker.getTableMetadata(table)) }
-  "getUpdates" should "be valid" in { check(DbVersionTracker.getUpdates(table)) }
+  "getUpdates in time order" should "be valid" in { check(DbVersionTracker.getUpdates(table, timeOrder = true)) }
+  "getUpdates in reverse order" should "be valid" in { check(DbVersionTracker.getUpdates(table, timeOrder = false)) }
   "addTable" should "be valid" in {
     check(
       DbVersionTracker

--- a/examples/src/test/scala/dev/chronicles/examples/MultiPartitionTableLoaderSpec.scala
+++ b/examples/src/test/scala/dev/chronicles/examples/MultiPartitionTableLoaderSpec.scala
@@ -102,7 +102,7 @@ class MultiPartitionTableLoaderSpec extends FlatSpec with Matchers with SparkHiv
       "impression_date=2019-03-14" -> "processed_date=2019-03-15")
 
     // Get version history
-    val versionHistory = metastore.updates(table.name).unsafeRunSync()
+    val versionHistory = metastore.updates(table.name).compile.toList.unsafeRunSync()
     versionHistory.size shouldBe 4 // One initial version plus three written versions
 
     // Roll back to previous version

--- a/examples/src/test/scala/dev/chronicles/examples/SnapshotTableLoaderSpec.scala
+++ b/examples/src/test/scala/dev/chronicles/examples/SnapshotTableLoaderSpec.scala
@@ -40,7 +40,7 @@ class SnapshotTableLoaderSpec extends FlatSpec with Matchers with SparkHiveSuite
 
     val loader = new TableLoader[User](versionContext, table, ddl, isSnapshot = true)
 
-    metastore.tables().unsafeRunSync() shouldBe Nil
+    metastore.tables().compile.toList.unsafeRunSync() shouldBe Nil
 
     loader.initTable(userId, UpdateMessage("init"))
 
@@ -53,7 +53,7 @@ class SnapshotTableLoaderSpec extends FlatSpec with Matchers with SparkHiveSuite
     loader.insert(identitiesDay1.toDS(), userId, "Committing first version from test")
 
     // We should see a new table
-    metastore.tables().unsafeRunSync() shouldBe List(table.name)
+    metastore.tables().compile.toList.unsafeRunSync() shouldBe List(table.name)
 
     // Query the table to make sure we have the right data
     val day1TableData = loader.data().collect()
@@ -72,7 +72,7 @@ class SnapshotTableLoaderSpec extends FlatSpec with Matchers with SparkHiveSuite
     loader.insert(identitiesDay2.toDS(), userId, "Committing second version from test")
 
     // We should still see a single table
-    metastore.tables().unsafeRunSync() shouldBe List(table.name)
+    metastore.tables().compile.toList.unsafeRunSync() shouldBe List(table.name)
 
     // Query it to make sure we have the right data
     val day2TableData = loader.data().collect()
@@ -84,7 +84,7 @@ class SnapshotTableLoaderSpec extends FlatSpec with Matchers with SparkHiveSuite
     updatedVersionDirs should contain allElementsOf initialTableVersionDirs
 
     // Get version history
-    val versionTracker = metastore.updates(table.name).unsafeRunSync()
+    val versionTracker = metastore.updates(table.name).compile.toList.unsafeRunSync()
     versionTracker.size shouldBe 3 // One initial version plus two written versions
 
     // Roll back to previous version

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,6 +24,8 @@ object Dependencies {
       "org.typelevel" %% "cats-effect" % "1.3.1"
     )
 
+  val fs2Version = "1.0.5"
+
   val doobieVersion = "0.7.0"
 
   lazy val doobieDependencies: Seq[ModuleID] =

--- a/spark/src/test/scala/dev/chronicles/spark/VersionContextSpec.scala
+++ b/spark/src/test/scala/dev/chronicles/spark/VersionContextSpec.scala
@@ -143,7 +143,7 @@ class VersionContextSpec extends FlatSpec with Matchers with SparkHiveSuite {
     tableVersion shouldBe SnapshotTableVersion(version1)
     metastoreChanges shouldBe stubbedChanges
 
-    val tableUpdates = metastore.updates(usersTable.name).unsafeRunSync()
+    val tableUpdates = metastore.updates(usersTable.name).compile.toList.unsafeRunSync()
     tableUpdates should have size 2
     val tableUpdate = tableUpdates.head
     tableUpdate.message shouldBe UpdateMessage("Test insert users into table")
@@ -202,7 +202,7 @@ class VersionContextSpec extends FlatSpec with Matchers with SparkHiveSuite {
     tableVersion shouldBe PartitionedTableVersion(expectedPartitionVersions)
     metastoreChanges shouldBe stubbedChanges
 
-    val tableUpdates = metastore.updates(eventsTable.name).unsafeRunSync()
+    val tableUpdates = metastore.updates(eventsTable.name).compile.toList.unsafeRunSync()
     tableUpdates should have size 2
     val tableUpdate = tableUpdates.head
     tableUpdate.message shouldBe UpdateMessage("Test insert events into table")
@@ -269,7 +269,7 @@ class VersionContextSpec extends FlatSpec with Matchers with SparkHiveSuite {
     tableVersion shouldBe PartitionedTableVersion(expectedPartitionVersions)
     metastoreChanges shouldBe stubbedChanges
 
-    val tableUpdates = metastore.updates(eventsTable.name).unsafeRunSync()
+    val tableUpdates = metastore.updates(eventsTable.name).compile.toList.unsafeRunSync()
     tableUpdates should have size 2
     val tableUpdate = tableUpdates.head
     tableUpdate.message shouldBe UpdateMessage("Test insert events into table")


### PR DESCRIPTION
The `VersionTracker` API has methods that returns tables, and the history of updates to a table. These used to return `List`s of items, which is potentially inefficient. Especially for the log of updates to a table, the client will often only care about the last few - it's redundant to pass the whole list back in this case. Also, there's a risk of running out of memory with very large lists of updates.

This PR replaces these uses of `List`s with `f2s.Stream`s instead.

A bit of refactoring went along with this. For example, we can no longer just reverse the list of updates when we want them in reverse order; we have to get them in that order from the underlying storage. Hence the DB code that queries for updates has a new parameter for the sort order.